### PR TITLE
v1.8.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,14 @@ jobs:
     - name: Build with Gradle Wrapper
       run: ./gradlew build
 
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: DiscordBot-Extension
+        path: |
+          bungeecord/build/libs/DiscordBot-\w*.jar
+          velocity/build/libs/DiscordBot-\w*.jar
+
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
     #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
       with:
         name: DiscordBot-Extension
         path: |
-          bungeecord/build/libs/DiscordBot-\w*.jar
-          velocity/build/libs/DiscordBot-\w*.jar
+          bungeecord/build/libs
+          velocity/build/libs
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ subprojects {
     dependencies {
         compileOnly(kotlin("stdlib"))
 
-        compileOnly("com.github.ProxioDev.redisbungee:RedisBungee-API:0.11.4")
+        compileOnly("com.github.ProxioDev.ValioBungee:RedisBungee-API:0.11.4")
 
         compileOnly("nl.chimpgamer.networkmanager:api:2.16.5")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.networkmanager.extensions"
-    version = "1.8.6"
+    version = "1.8.7-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "nl.chimpgamer.networkmanager.extensions"
-    version = "1.8.7-SNAPSHOT"
+    version = "1.8.7"
 
     repositories {
         mavenCentral()

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     compileOnly("net.md-5:bungeecord-api:1.19-R0.1-SNAPSHOT")
 
-    compileOnly("com.github.ProxioDev.redisbungee:RedisBungee-Bungee:0.11.4")
+    compileOnly("com.github.ProxioDev.ValioBungee:RedisBungee-Bungee:0.11.4")
 }
 
 tasks {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     compileOnly("com.gitlab.ruany", "LiteBansAPI", "0.3.5")
 
-    implementation("net.dv8tion:JDA:5.1.0") {
+    implementation("net.dv8tion:JDA:5.1.2") {
         exclude("club.minnced", "opus-java")
     }
 

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/DiscordBot.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/DiscordBot.kt
@@ -91,6 +91,7 @@ class DiscordBot(val platform: Platform) {
         this.settings.reload()
         this.commandSettings.reload()
         this.messages.reload()
+        discordManager.setOnlineStatus()
     }
 
     private fun registerListeners() {

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/CommandSettings.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/CommandSettings.kt
@@ -32,6 +32,9 @@ class CommandSettings(discordBot: DiscordBot) {
     val discordRegisterCommand: String get() = config.getString("commands.discord.register.command", "register")
     val discordRegisterDescription: String get() = config.getString("commands.discord.register.description", "Register your discord account with your minecraft account on our server")
 
+    val discordTicketCommand: String get() = config.getString("commands.discord.ticket.command", "ticket")
+    val discordTicketDescription: String get() = config.getString("commands.discord.ticket.description", "Create a new ticket.")
+
     val minecraftDiscordEnabled: Boolean get() = config.getBoolean("commands.minecraft.discord.enabled", false)
 
     val minecraftSuggestionEnabled: Boolean get() = config.getBoolean("commands.minecraft.suggestion.enabled", false)

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/Messages.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/Messages.kt
@@ -23,6 +23,8 @@ class Messages(discordBot: DiscordBot) {
         }
     }
 
+    val discordCommandTicketAccountNotLinked: String get() = config.getString("discord.command.ticket.account-not-linked")
+
     val discordCommandTicketModalTitle: String get() = config.getString("discord.command.ticket.modal.title")
 
     val discordCommandTicketModalInputTitleLabel: String get() = config.getString("discord.command.ticket.modal.input.title.label")

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/Settings.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/configurations/Settings.kt
@@ -11,6 +11,8 @@ import nl.chimpgamer.networkmanager.extensions.discordbot.shared.DiscordBot
 class Settings(private val discordBot: DiscordBot) {
     private val config: YamlDocument
 
+    val botDiscordOnlineStatus: String get() = config.getString("bot.discord.online-status")
+
     init {
         val file = discordBot.dataFolder.resolve("settings.yml")
         val inputStream = discordBot.platform.getResource("settings.yml")

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
@@ -257,10 +257,7 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
             val isLinked =
                 runCatching { discordBot.discordUserManager.checkUserByDiscordId(member.id) }.getOrDefault(false)
             if (!isLinked) {
-                event.reply_(
-                    "You'll have to link your account before you can open a ticket using this command!",
-                    ephemeral = true
-                ).await()
+                event.reply_(discordBot.messages.discordCommandTicketAccountNotLinked, ephemeral = true).await()
                 return@onCommand
             }
 

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
@@ -63,6 +63,9 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
         val uptimeCommandName = commandSettings.discordUptimeCommand
         val uptimeCommandDescription = commandSettings.discordUptimeDescription
 
+        val ticketCommandName = commandSettings.discordTicketCommand
+        val ticketCommandDescription = commandSettings.discordTicketDescription
+
         jda.updateCommands {
             slash(registerCommandName, registerCommandDescription)
 
@@ -83,7 +86,7 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
                 restrict(guild = true, Permission.MESSAGE_SEND)
             }
 
-            slash("ticket", "Create a new ticket") {
+            slash(ticketCommandName, ticketCommandDescription) {
                 restrict(guild = true, Permission.MESSAGE_SEND)
             }
         }.await()

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordCommandsListener.kt
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.interactions.components.text.TextInputStyle
 import net.dv8tion.jda.api.utils.data.DataObject
 import nl.chimpgamer.networkmanager.api.utils.TimeUtils
 import nl.chimpgamer.networkmanager.api.utils.ExpiringMap
+import nl.chimpgamer.networkmanager.api.values.Module
 import nl.chimpgamer.networkmanager.extensions.discordbot.shared.DiscordBot
 import nl.chimpgamer.networkmanager.extensions.discordbot.shared.configurations.DCMessage
 import nl.chimpgamer.networkmanager.extensions.discordbot.shared.tasks.CreateTokenTask
@@ -46,6 +47,8 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
 
     private suspend fun handleCommands(jda: JDA) {
         val commandSettings = discordBot.commandSettings
+        val cachedValues = discordBot.networkManager.cacheManager.cachedValues
+
         val registerCommandName = commandSettings.discordRegisterCommand
         val registerCommandDescription = commandSettings.discordRegisterDescription
 
@@ -86,8 +89,10 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
                 restrict(guild = true, Permission.MESSAGE_SEND)
             }
 
-            slash(ticketCommandName, ticketCommandDescription) {
-                restrict(guild = true, Permission.MESSAGE_SEND)
+            if (cachedValues.getBoolean(Module.TICKETS)) {
+                slash(ticketCommandName, ticketCommandDescription) {
+                    restrict(guild = true, Permission.MESSAGE_SEND)
+                }
             }
         }.await()
 
@@ -247,7 +252,7 @@ class DiscordCommandsListener(private val discordBot: DiscordBot) : CoroutineEve
             event.reply(TimeUtils.getTimeString(language, (System.currentTimeMillis() - uptime) / 1000)).await()
         }
 
-        jda.onCommand("ticket") { event ->
+        jda.onCommand(ticketCommandName) { event ->
             val member = event.member ?: return@onCommand
             val isLinked =
                 runCatching { discordBot.discordUserManager.checkUserByDiscordId(member.id) }.getOrDefault(false)

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordListener.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/DiscordListener.kt
@@ -98,7 +98,7 @@ class DiscordListener(private val discordBot: DiscordBot) : CoroutineEventListen
                 if (message.isEmpty()) {
                     return
                 }
-                member.user.openPrivateChannel().await().sendMessage(message.replace("%mention%", member.user.asMention)).await()
+                member.user.openPrivateChannel().flatMap { it.sendMessage(message.replace("%mention%", member.user.asMention)) }.await()
             }
         }
     }

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/NetworkManagerListeners.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/listeners/NetworkManagerListeners.kt
@@ -31,8 +31,10 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
     private fun onStaffChat(event: StaffChatEvent) {
         if (event.isCancelled) return
         val sender = event.sender
-        val staffChatChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_STAFFCHAT_CHANNEL) ?: return
-        val staffChatMessage = discordBot.messages.getString(DCMessage.EVENT_STAFFCHAT).replace("%message%", event.message)
+        val staffChatChannel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_STAFFCHAT_CHANNEL) ?: return
+        val staffChatMessage =
+            discordBot.messages.getString(DCMessage.EVENT_STAFFCHAT).replace("%message%", event.message)
         val componentMessage = staffChatMessage.parse(sender)
             .replace("%playername%", sender.name())
             .replace("%displayname%", sender.displayName)
@@ -43,8 +45,10 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
     private fun onAdminChat(event: AdminChatEvent) {
         if (event.isCancelled) return
         val sender = event.sender
-        val adminChatChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_ADMINCHAT_CHANNEL) ?: return
-        val adminChatMessage = discordBot.messages.getString(DCMessage.EVENT_ADMINCHAT) .replace("%message%", event.message)
+        val adminChatChannel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_ADMINCHAT_CHANNEL) ?: return
+        val adminChatMessage =
+            discordBot.messages.getString(DCMessage.EVENT_ADMINCHAT).replace("%message%", event.message)
         val componentMessage = adminChatMessage.parse(sender)
             .replace("%playername%", sender.name())
             .replace("%displayname%", sender.displayName)
@@ -58,13 +62,16 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
         val globalId = serverChannels["all"] ?: "000000000000000000"
         val channelId = serverChannels[server.serverName] ?: "000000000000000000"
         val textChannel =
-            discordBot.discordManager.getTextChannelById(globalId) ?: discordBot.discordManager.getTextChannelById(channelId) ?: return
+            discordBot.discordManager.getTextChannelById(globalId) ?: discordBot.discordManager.getTextChannelById(
+                channelId
+            ) ?: return
         val dcMessage = if (event.isOnline) DCMessage.SERVER_STATUS_ONLINE else DCMessage.SERVER_STATUS_OFFLINE
 
         val data = DataObject.fromJson(discordBot.messages.getString(dcMessage))
         val embedBuilder = EmbedBuilder.fromData(data).apply {
             val title = insertServerPlaceholders(data.getString("title", null), server)
-            val description = insertServerPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, server)
+            val description =
+                insertServerPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, server)
             setTitle(title)
             setDescription(description)
             parsePlaceholdersToFields { text -> insertServerPlaceholders(text, server) }
@@ -75,12 +82,16 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
 
     private fun onPunishment(event: PunishmentEvent) {
         if (event.punishment.type === Punishment.Type.REPORT) {
-            val reportChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_REPORT_CHANNEL) ?: return
+            val reportChannel =
+                discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_REPORT_CHANNEL) ?: return
             if (event.punishment.isActive) {
                 val data = DataObject.fromJson(discordBot.messages.getString(DCMessage.REPORT_ALERT))
                 val embedBuilder = EmbedBuilder.fromData(data).apply {
                     val title = insertPunishmentPlaceholders(data.getString("title", null), event)
-                    val description = insertPunishmentPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
+                    val description = insertPunishmentPlaceholders(
+                        data.getString("description", "").takeIf { it.isNotEmpty() },
+                        event
+                    )
                     setTitle(title)
                     setDescription(description)
                     parsePlaceholdersToFields { text -> insertPunishmentPlaceholders(text, event) }
@@ -98,7 +109,8 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
             val data = DataObject.fromJson(discordBot.messages.getString(dcMessage))
             val embedBuilder = EmbedBuilder.fromData(data).apply {
                 val title = insertPunishmentPlaceholders(data.getString("title", null), event)
-                val description = insertPunishmentPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
+                val description =
+                    insertPunishmentPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
                 setTitle(title)
                 setDescription(description)
                 parsePlaceholdersToFields { text -> insertPunishmentPlaceholders(text, event) }
@@ -112,12 +124,14 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
         if (event.isCancelled) {
             return
         }
-        val helpOPChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_HELPOP_CHANNEL) ?: return
+        val helpOPChannel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_HELPOP_CHANNEL) ?: return
 
         val data = DataObject.fromJson(discordBot.messages.getString(DCMessage.HELPOP_ALERT))
         val embedBuilder = EmbedBuilder.fromData(data).apply {
             val title = insertHelpOPPlaceholders(data.getString("title", null), event)
-            val description = insertHelpOPPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
+            val description =
+                insertHelpOPPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
             setTitle(title)
             setDescription(description)
             parsePlaceholdersToFields { text -> insertHelpOPPlaceholders(text, event) }
@@ -127,12 +141,14 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
     }
 
     private fun onTicketCreate(event: TicketCreateEvent) {
-        val ticketChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_TICKETS_CHANNEL) ?: return
+        val ticketChannel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_TICKETS_CHANNEL) ?: return
 
         val data = DataObject.fromJson(discordBot.messages.getString(DCMessage.TICKET_CREATE_ALERT))
         val embedBuilder = EmbedBuilder.fromData(data).apply {
             val title = insertTicketPlaceholders(data.getString("title", null), event)
-            val description = insertTicketPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
+            val description =
+                insertTicketPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
             setTitle(title)
             setDescription(description)
             parsePlaceholdersToFields { text -> insertTicketPlaceholders(text, event) }
@@ -142,12 +158,14 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
     }
 
     private fun onChatLogCreated(event: ChatLogCreatedEvent) {
-        val chatLogChannel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_CHATLOG_CHANNEL) ?: return
+        val chatLogChannel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_CHATLOG_CHANNEL) ?: return
 
         val data = DataObject.fromJson(discordBot.messages.getString(DCMessage.CHATLOG_ALERT))
         val embedBuilder = EmbedBuilder.fromData(data).apply {
             val title = insertChatLogPlaceholders(data.getString("title", null), event)
-            val description = insertChatLogPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
+            val description =
+                insertChatLogPlaceholders(data.getString("description", "").takeIf { it.isNotEmpty() }, event)
             setTitle(title)
             setDescription(description)
             parsePlaceholdersToFields { text -> insertChatLogPlaceholders(text, event) }
@@ -181,7 +199,10 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
                     ?: return
             sendChannelMessage(
                 channel,
-                Placeholders.setPlaceholders(player, discordBot.messages.getString(DCMessage.EVENT_PLAYERLOGIN))
+                discordBot.messages.getString(DCMessage.EVENT_PLAYERLOGIN)
+                    .replace("%playername%", player.name)
+                    .parse(player)
+                    .toPlainText()
             )
         } else {
             val channel =
@@ -189,7 +210,10 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
                     ?: return
             sendChannelMessage(
                 channel,
-                Placeholders.setPlaceholders(player, discordBot.messages.getString(DCMessage.EVENT_FIRST_PLAYERLOGIN))
+                discordBot.messages.getString(DCMessage.EVENT_FIRST_PLAYERLOGIN)
+                    .replace("%playername%", player.name)
+                    .parse(player)
+                    .toPlainText()
             )
         }
     }
@@ -199,7 +223,13 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
         val channel =
             discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_DISCONNECT_CHANNEL)
                 ?: return
-        sendChannelMessage(channel, Placeholders.setPlaceholders(player, discordBot.messages.getString(DCMessage.EVENT_DISCONNECT)))
+        sendChannelMessage(
+            channel,
+            discordBot.messages.getString(DCMessage.EVENT_DISCONNECT)
+                .replace("%playername%", player.name)
+                .parse(player)
+                .toPlainText()
+        )
     }
 
     private fun onServerConnected(event: ServerConnectedEvent) {
@@ -211,10 +241,13 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
             discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_SERVER_SWITCH_CHANNEL)
                 ?: return
 
-        val message = Placeholders.setPlaceholders(player, discordBot.messages.getString(DCMessage.EVENT_SERVER_SWITCH)
+        val message = discordBot.messages.getString(DCMessage.EVENT_SERVER_SWITCH)
+            .replace("%playername%", player.name)
             .replace("%previous-server%", previousServer.serverName)
             .replace("%server%", server.serverName)
-        )
+            .parse(player)
+            .toPlainText()
+
         sendChannelMessage(channel, message)
     }
 
@@ -323,12 +356,15 @@ class NetworkManagerListeners(private val discordBot: DiscordBot) {
     }
 
     private fun onMaintenanceModeToggle(event: MaintenanceModeToggleEvent) {
-        val channel = discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_MAINTENANCE_MODE_CHANNEL) ?: return
-        val message = if (event.enabled) DCMessage.MAINTENANCE_MODE_ALERT_ENABLED else DCMessage.MAINTENANCE_MODE_ALERT_DISABLED
+        val channel =
+            discordBot.discordManager.getTextChannelById(Setting.DISCORD_EVENTS_MAINTENANCE_MODE_CHANNEL) ?: return
+        val message =
+            if (event.enabled) DCMessage.MAINTENANCE_MODE_ALERT_ENABLED else DCMessage.MAINTENANCE_MODE_ALERT_DISABLED
         val data = DataObject.fromJson(discordBot.messages.getString(message))
         val embedBuilder = EmbedBuilder.fromData(data).apply {
             val title = data.getString("title", null)?.replace("%state%", event.enabled.toString())
-            val description = data.getString("description", "").takeIf { it.isNotEmpty() }?.replace("%state%", event.enabled.toString())
+            val description = data.getString("description", "").takeIf { it.isNotEmpty() }
+                ?.replace("%state%", event.enabled.toString())
             setTitle(title)
             setDescription(description)
             parsePlaceholdersToFields { text -> text.replace("%state%", event.enabled.toString()) }

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/manager/DiscordManager.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/manager/DiscordManager.kt
@@ -195,7 +195,7 @@ class DiscordManager(private val discordBot: DiscordBot) {
     fun setNickNameAndAddRole(member: Member, nickName: String, role: Role) {
         var finalNickname = nickName
         if (nickName.length > 32) {
-            discordBot.platform.info("The new nickname of ${member.user.name} exceeds the maximum limit of 32 characters.")
+            discordBot.platform.warn("The new nickname of ${member.user.name} exceeds the maximum limit of 32 characters.")
             finalNickname = finalNickname.substring(0, 32)
         }
         discordBot.platform.info("Setting nickname and role for " + member.user.name)

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/manager/DiscordManager.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/manager/DiscordManager.kt
@@ -3,6 +3,7 @@ package nl.chimpgamer.networkmanager.extensions.discordbot.shared.manager
 import dev.minn.jda.ktx.events.listener
 import dev.minn.jda.ktx.jdabuilder.light
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.OnlineStatus
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.entities.Guild
@@ -88,10 +89,13 @@ class DiscordManager(private val discordBot: DiscordBot) {
             setMaxReconnectDelay(180)
         }.awaitReady()
 
-        jda.listener<ReadyEvent> { discordBot.platform.info("Bot is ready!") }
+        jda.listener<ReadyEvent> { discordBot.platform.info("Bot is ready!")}
     }
 
+    fun setOnlineStatus() = jda.presence.setStatus(OnlineStatus.fromKey(discordBot.settings.botDiscordOnlineStatus))
+
     private fun initializeActivity() {
+        setOnlineStatus()
         if (discordBot.settings.getBoolean(Setting.DISCORD_STATUS_ENABLED)) {
             val activityType = try {
                 Activity.ActivityType.valueOf(discordBot.settings.getString(Setting.DISCORD_STATUS_TYPE).uppercase())
@@ -119,6 +123,7 @@ class DiscordManager(private val discordBot: DiscordBot) {
         shutdownJDA()
         try {
             initJDA()
+            initializeActivity()
             return true
         } catch (e: LoginException) {
             e.printStackTrace()

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/tasks/DeleteUserTask.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/tasks/DeleteUserTask.kt
@@ -55,10 +55,10 @@ class DeleteUserTask(private val discordBot: DiscordBot, private val player: Pla
                 }
 
                 val unregisterNotification = discordBot.messages.getString(DCMessage.REGISTRATION_UNREGISTER_NOTIFICATION)
-                if (unregisterNotification.isNotEmpty()) {
+                if (member != null && unregisterNotification.isNotEmpty()) {
                     val data = DataObject.fromJson(unregisterNotification)
                     val embedBuilder = EmbedBuilder.fromData(data)
-                    member?.user?.openPrivateChannel()?.flatMap { channel -> channel.sendMessageEmbeds(embedBuilder.build()) }?.queue()
+                    member.user.openPrivateChannel().flatMap { channel -> channel.sendMessageEmbeds(embedBuilder.build()) }.queue()
                 }
 
                 if (discordBot.settings.getBoolean(Setting.DISCORD_UNREGISTER_KICK_ENABLED)) {

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/tasks/GuildJoinCheckTask.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/tasks/GuildJoinCheckTask.kt
@@ -44,7 +44,7 @@ class GuildJoinCheckTask(private val discordBot: DiscordBot, private val member:
                             if (welcomeMessage.isEmpty()) {
                                 return
                             }
-                            member.user.openPrivateChannel().queue { it.sendMessage(welcomeMessage.replace("%mention%", member.user.asMention)).queue() }
+                            member.user.openPrivateChannel().flatMap { it.sendMessage(welcomeMessage.replace("%mention%", member.user.asMention)) }.queue()
                         }
                     }
                 }

--- a/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/utils/Utils.kt
+++ b/shared/src/main/kotlin/nl/chimpgamer/networkmanager/extensions/discordbot/shared/utils/Utils.kt
@@ -18,6 +18,7 @@ import java.math.BigInteger
 import java.security.SecureRandom
 import java.util.*
 import java.util.function.Function
+import java.util.logging.Level
 
 object Utils {
     val UUID_REGEX = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[34][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}")
@@ -35,7 +36,7 @@ object Utils {
         try {
             channel.sendMessage(message).queue()
         } catch (ex: PermissionException) {
-            discordBot.platform.warn("Could not send message to the " + channel.name + " because " + ex.message)
+            discordBot.platform.logger.log(Level.WARNING, "Could not send message to the ${channel.name} channel.", ex)
         }
     }
 
@@ -43,7 +44,7 @@ object Utils {
         try {
             channel.sendMessageEmbeds(message).queue()
         } catch (ex: PermissionException) {
-            discordBot.platform.warn("Could not send message to the " + channel.name + " because " + ex.message)
+            discordBot.platform.logger.log(Level.WARNING, "Could not send embed message to the ${channel.name} channel.", ex)
         }
     }
 

--- a/shared/src/main/resources/commands.yml
+++ b/shared/src/main/resources/commands.yml
@@ -25,6 +25,9 @@ commands:
       command: register
       description: Register your discord account with your minecraft account on our
         server
+    ticket:
+      command: ticket
+      description: Create a new ticket.
   minecraft:
     discord:
       enabled: false
@@ -43,4 +46,4 @@ commands:
       command: unregister
       aliases: unlink
 
-config-version: 1
+config-version: 2

--- a/shared/src/main/resources/messages.yml
+++ b/shared/src/main/resources/messages.yml
@@ -60,6 +60,7 @@ discord:
           "showTimestamp": true
         }
     ticket:
+      account-not-linked: "You'll have to link your account before you can open a ticket using this command!"
       modal:
         title: 'Create Ticket'
         input:
@@ -543,4 +544,4 @@ discord:
         "showTimestamp": true
       }
 
-config-version: 4
+config-version: 5

--- a/shared/src/main/resources/settings.yml
+++ b/shared/src/main/resources/settings.yml
@@ -3,6 +3,7 @@ bot:
     token: YourBotTokenHere
     main-guild: '000000000000000000'
     max-guilds: 1
+    online-status: online
     status:
       enabled: true
       type: watching
@@ -63,4 +64,4 @@ bot:
       registration-alerts:
         channel: '000000000000000000'
 
-config-version: 3
+config-version: 4

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     compileOnly("com.velocitypowered:velocity-api:3.1.1")
 
-    compileOnly("com.github.ProxioDev.redisbungee:RedisBungee-Velocity:0.11.4")
+    compileOnly("com.github.ProxioDev.ValioBungee:RedisBungee-Velocity:0.11.4")
 }
 
 tasks {


### PR DESCRIPTION
Changes:
- Added online status setting
- Fixed color stripping in chat message and add support for internal placeholders in adminchat and staffchat messages.
- Allow placeholders in join and leave messages.
- Bump JDA to 5.1.2.
- Ticket command and description is now configurable.
- Make sure to only register the ticket command for discord when the tickets module is enabled.
- Added ticket account not linked message.